### PR TITLE
Group all compiled output in `lib` folder

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,5 +1,3 @@
 /**/node_modules
 
-/packages/*/internal
-/packages/*/index.*
-/packages/bin/spicy.*
+/packages/*/lib

--- a/.gitignore
+++ b/.gitignore
@@ -5,9 +5,7 @@
 /**/yarn-error.log
 /**/tsconfig.tsbuildinfo
 
-/packages/*/internal
-/packages/*/index.*
-/packages/bin/spicy.*
+/packages/*/lib
 
 /**/.env
 /**/.env.*

--- a/packages/bin/package.json
+++ b/packages/bin/package.json
@@ -7,6 +7,10 @@
     "url": "https://github.com/salsita/spicy-hooks.git",
     "directory": "packages/bin"
   },
+  "files": [
+    "lib",
+    "src"
+  ],
   "dependencies": {
     "@expo/spawn-async": "^1.5.0",
     "@octokit/core": "^3.1.2",
@@ -27,6 +31,6 @@
     "typescript": "^4.0.3"
   },
   "bin": {
-    "spicy": "./spicy.js"
+    "spicy": "./lib/spicy.js"
   }
 }

--- a/packages/bin/tsconfig.json
+++ b/packages/bin/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "outDir": ".",
+    "outDir": "lib",
     "rootDir": "src",
     "tsBuildInfoFile": "./tsconfig.tsbuildinfo"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -8,10 +8,11 @@
     "directory": "packages/core"
   },
   "files": [
-    "internal",
-    "index.*",
+    "lib",
     "src"
   ],
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "dependencies": {
     "@spicy-hooks/utils": "0.1.0",
     "tslib": "^2.0.1"

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "outDir": ".",
+    "outDir": "lib",
     "rootDir": "src",
     "tsBuildInfoFile": "./tsconfig.tsbuildinfo"
   },

--- a/packages/observables/package.json
+++ b/packages/observables/package.json
@@ -8,10 +8,11 @@
     "directory": "packages/observables"
   },
   "files": [
-    "internal",
-    "index.*",
+    "lib",
     "src"
   ],
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "dependencies": {
     "@spicy-hooks/utils": "0.1.0",
     "@spicy-hooks/core": "0.1.0",

--- a/packages/observables/tsconfig.json
+++ b/packages/observables/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "outDir": ".",
+    "outDir": "lib",
     "rootDir": "src",
     "tsBuildInfoFile": "./tsconfig.tsbuildinfo"
   },

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -8,10 +8,11 @@
     "directory": "packages/utils"
   },
   "files": [
-    "internal",
-    "index.*",
+    "lib",
     "src"
   ],
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "dependencies": {
     "tslib": "^2.0.1"
   },

--- a/packages/utils/tsconfig.json
+++ b/packages/utils/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "outDir": ".",
+    "outDir": "lib",
     "rootDir": "src",
     "tsBuildInfoFile": "./tsconfig.tsbuildinfo"
   },


### PR DESCRIPTION
Each package will from now on contain a `lib` folder with TSC output.
The `main` and `types` properties of `package.json` will forward the user to appropriate files.