### PR TITLE
Add `redirect-refs` command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,9 @@ jobs:
       - name: Build Typedoc
         run: yarn typedoc --gitRevision $GITHUB_TAG --name "@spicy-hooks $GITHUB_TAG"
 
+      - name: Redirect references to proper tag
+        run: yarn redirect-refs
+
       - name: Install awscli
         run: sudo pip install awscli
 

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "test": "jest",
     "lint": "eslint . --ext .js,.ts,.tsx",
     "typedoc": "typedoc packages/core/src/index.ts packages/observables/src/index.ts packages/utils/src/index.ts",
-    "spicy": "cross-env node packages/bin/spicy.js"
+    "redirect-refs": "yarn spicy redirect-refs {packages/**/*.md,typedoc/**/*.html} -b next -p https://spicy-hooks.salsita.co https://github.com/salsita/spicy-hooks/tree https://github.com/salsita/spicy-hooks/blob",
+    "spicy": "cross-env node packages/bin/lib/spicy.js"
   },
   "changelogs": {
     "separator": "\n## ",

--- a/packages/bin/package.json
+++ b/packages/bin/package.json
@@ -15,11 +15,7 @@
     "@expo/spawn-async": "^1.5.0",
     "@octokit/core": "^3.1.2",
     "@spicy-hooks/utils": "0.1.0",
-    "@types/command-line-args": "^5.0.0",
-    "@types/dotenv": "^8.2.0",
-    "@types/fs-extra": "^9.0.1",
-    "@types/glob": "^7.1.3",
-    "@types/lodash": "^4.14.161",
+    "chalk": "^4.1.0",
     "command-line-args": "^5.1.1",
     "dotenv": "^8.2.0",
     "fs-extra": "^9.0.1",
@@ -28,6 +24,11 @@
     "tslib": "^2.0.1"
   },
   "devDependencies": {
+    "@types/command-line-args": "^5.0.0",
+    "@types/dotenv": "^8.2.0",
+    "@types/fs-extra": "^9.0.1",
+    "@types/glob": "^7.1.3",
+    "@types/lodash": "^4.14.161",
     "typescript": "^4.0.3"
   },
   "bin": {

--- a/packages/bin/src/internal/commands/index.ts
+++ b/packages/bin/src/internal/commands/index.ts
@@ -1,3 +1,4 @@
 export { checkVersionCommand } from './check-version-command'
 export { setVersionCommand } from './set-version-command'
 export { prepareReleaseCommand } from './prepare-release-command'
+export { redirectRefsCommand } from './redirect-refs-command'

--- a/packages/bin/src/internal/commands/redirect-refs-command.ts
+++ b/packages/bin/src/internal/commands/redirect-refs-command.ts
@@ -1,0 +1,115 @@
+import { promisify } from 'util'
+import { resolve } from 'path'
+import glob from 'glob'
+import { greenBright, gray } from 'chalk'
+import { readFile, writeFile } from 'fs-extra'
+import { escapeRegExp } from 'lodash'
+
+import { CommandDefinition } from '../utils/command-definition'
+import { readPackageJson } from '../utils/package-json'
+import { getGitHubRepository } from '../utils/github'
+
+const globAsync = promisify(glob)
+
+interface RedirectRefsOption {
+  filePattern: string
+  prefixes: string[]
+  'main-branch': string
+  root: string
+  ignore: string
+  quiet: boolean
+  verbose: boolean
+}
+
+export const redirectRefsCommand: CommandDefinition<RedirectRefsOption> = {
+  command: 'redirect-refs',
+  options: {
+    filePattern: {
+      defaultOption: true,
+      type: String,
+      defaultValue: '{**/*.md,**/*.html}'
+    },
+    prefixes: {
+      alias: 'p',
+      type: String,
+      multiple: true
+    },
+    'main-branch': {
+      defaultValue: 'master',
+      alias: 'b',
+      type: String
+    },
+    root: {
+      alias: 'r',
+      defaultValue: './',
+      type: String
+    },
+    ignore: {
+      alias: 'i',
+      type: String,
+      defaultValue: '**/node_modules/**/*.*'
+    },
+    quiet: {
+      alias: 'q',
+      type: Boolean,
+      defaultValue: false
+    },
+    verbose: {
+      alias: 'v',
+      type: Boolean,
+      defaultValue: false
+    }
+  },
+  execute: async (
+    {
+      root,
+      prefixes,
+      'main-branch': mainBranch,
+      filePattern,
+      ignore,
+      quiet,
+      verbose
+    }
+  ) => {
+    const rootDir = resolve(root)
+    const rootPackageJsonFile = resolve(rootDir, 'package.json')
+    const rootPackageJson = await readPackageJson(rootPackageJsonFile)
+    if (prefixes == null) {
+      const { owner, repo } = getGitHubRepository(rootPackageJson)
+      prefixes = [
+        `https://github.com/${owner}/${repo}/tree`,
+        `https://github.com/${owner}/${repo}/blob`
+      ]
+    }
+
+    const targetRef = `v${rootPackageJson.version}`
+
+    const prefixVariants = prefixes
+      .map(escapeRegExp)
+      .join('|')
+
+    const replacePattern = new RegExp(`(${prefixVariants})/${mainBranch}/`, 'g')
+    const replaceSubstitution = `$1/${targetRef}/`
+
+    const files = await globAsync(filePattern, { ignore })
+
+    const redirections = await Promise.all(files.map(async file => {
+      const content = await readFile(file, 'utf-8')
+      const redirectedContent = content.replace(replacePattern, replaceSubstitution)
+      if (content !== redirectedContent) {
+        await writeFile(file, redirectedContent)
+        if (!quiet) {
+          console.log(greenBright(file))
+        }
+        return true
+      }
+      if (verbose) {
+        console.log(gray(file))
+      }
+      return false
+    }))
+
+    console.log(`Redirected ${redirections.filter(Boolean).length} out of ${files.length} files `)
+    return 0
+  }
+}

--- a/packages/bin/src/spicy.ts
+++ b/packages/bin/src/spicy.ts
@@ -4,14 +4,15 @@ import { config } from 'dotenv'
 
 import { CommandDefinition } from './internal/utils/command-definition'
 import { typedCommandLineArgs, TypedOptionDefinitions } from './internal/utils/typed-command-line-arguments'
-import { checkVersionCommand, prepareReleaseCommand, setVersionCommand } from './internal/commands'
+import { checkVersionCommand, prepareReleaseCommand, redirectRefsCommand, setVersionCommand } from './internal/commands'
 
 config()
 
 const commandDefinitions: Array<CommandDefinition<any>> = [
   checkVersionCommand,
   setVersionCommand,
-  prepareReleaseCommand
+  prepareReleaseCommand,
+  redirectRefsCommand
 ]
 
 const supportedCommands = commandDefinitions

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,3 +1,7 @@
 # @spicy-hooks/core
 
 React Hooks of general use.
+
+## Documentation
+
+* [API reference](https://spicy-hooks.salsita.co/next/modules/_core_src_index_.html) 

--- a/packages/observables/README.md
+++ b/packages/observables/README.md
@@ -1,3 +1,7 @@
 # @spicy-hooks/observables
 
 React Hooks for easy plugging of RxJS observables into React.
+
+## Documentation
+
+* [API reference](https://spicy-hooks.salsita.co/next/modules/_observables_src_index_.html) 

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -1,3 +1,7 @@
 # @spicy-hooks/utils
 
 General utility functions and types used within the `@spicy-hooks` project, but useful for other projects as well.  
+
+## Documentation
+
+* [API reference](https://spicy-hooks.salsita.co/next/modules/_utils_src_index_.html) 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1276,7 +1276,7 @@ chalk@^3.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-chalk@^4.0.0:
+chalk@^4.0.0, chalk@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.0.tgz#4e14870a618d9e2edd97dd8345fd9d9dc315646a"
   integrity sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==


### PR DESCRIPTION
This PR adds a `redirect-refs` command that changes links to `<prefix>/<main-branch>` to `<prefix>/v<package-version>`.