### PR TITLE
Keep the changelog concise

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,40 +1,40 @@
 name-template: 'v$RESOLVED_VERSION'
 tag-template: 'v$RESOLVED_VERSION'
 categories:
-  - title: '`@spicy-hooks/core` - Breaking changes'
+  - title: '`core` - Breaking changes'
     labels:
       - 'CORE breaking'
-  - title: '`@spicy-hooks/core` - Features / enhancements'
+  - title: '`core` - Features / enhancements'
     labels:
       - 'CORE feature'
-  - title: '`@spicy-hooks/core` - Bug fixes'
+  - title: '`core` - Bug fixes'
     labels:
       - 'CORE fix'
-  - title: '`@spicy-hooks/observables` - Breaking changes'
+  - title: '`observables` - Breaking changes'
     labels:
       - 'OBSERVABLES breaking'
-  - title: '`@spicy-hooks/observables` - Features / enhancements'
+  - title: '`observables` - Features / enhancements'
     labels:
       - 'OBSERVABLES feature'
-  - title: '`@spicy-hooks/observables` - Bug fixes'
+  - title: '`observables` - Bug fixes'
     labels:
       - 'OBSERVABLES fix'
-  - title: '`@spicy-hooks/bin` - Breaking changes'
+  - title: '`bin` - Breaking changes'
     labels:
       - 'BIN breaking'
-  - title: '`@spicy-hooks/bin` - Features / enhancements'
+  - title: '`bin` - Features / enhancements'
     labels:
       - 'BIN feature'
-  - title: '`@spicy-hooks/bin` - Bug fixes'
+  - title: '`bin` - Bug fixes'
     labels:
       - 'BIN fix'
-  - title: '`@spicy-hooks/utils` - Breaking changes'
+  - title: '`utils` - Breaking changes'
     labels:
       - 'UTILS breaking'
-  - title: '`@spicy-hooks/utils` - Features / enhancements'
+  - title: '`utils` - Features / enhancements'
     labels:
       - 'UTILS feature'
-  - title: '`@spicy-hooks/utils` - Bug fixes'
+  - title: '`utils` - Bug fixes'
     labels:
       - 'UTILS fix'
 exclude-labels:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # v0.1.0
 _Oct 5, 2020_
 
-## `@spicy-hooks/bin` - Features / enhancements
+## `bin` - Features / enhancements
 
 - Allow to specify direct filename for a changelog (#5) @goce-cz
 
@@ -9,11 +9,11 @@ _Oct 5, 2020_
 # v0.0.1
 _Oct 5, 2020_
 
-## `@spicy-hooks/observables` - Features / enhancements
+## `observables` - Features / enhancements
 
 - Add high level concepts (#1) @goce-cz 
 
-## `@spicy-hooks/bin` - Features / enhancements
+## `bin` - Features / enhancements
 
 - Add `prepare-release` command (#3) @goce-cz
 

--- a/package.json
+++ b/package.json
@@ -55,19 +55,19 @@
         "packageName": "spicy-hooks"
       },
       {
-        "pattern": "^(## )`@spicy-hooks/core` - ",
+        "pattern": "^(## )`core` - ",
         "packageName": "@spicy-hooks/core"
       },
       {
-        "pattern": "^(## )`@spicy-hooks/observables` - ",
+        "pattern": "^(## )`observables` - ",
         "packageName": "@spicy-hooks/observables"
       },
       {
-        "pattern": "^(## )`@spicy-hooks/bin` - ",
+        "pattern": "^(## )`bin` - ",
         "packageName": "@spicy-hooks/bin"
       },
       {
-        "pattern": "^(## )`@spicy-hooks/utils` - ",
+        "pattern": "^(## )`utils` - ",
         "packageName": "@spicy-hooks/utils"
       }
     ]


### PR DESCRIPTION
This PR removes `@spicy-hooks/` prefix from changelog and release notes headers.