### PR TITLE
Simplify configuration of `prepare-release` command

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,23 +52,23 @@
     "mappings": [
       {
         "pattern": "(.)",
-        "packageName": "spicy-hooks"
+        "file": "CHANGELOG.md"
       },
       {
         "pattern": "^(## )`core` - ",
-        "packageName": "@spicy-hooks/core"
+        "file": "packages/core/CHANGELOG.md"
       },
       {
         "pattern": "^(## )`observables` - ",
-        "packageName": "@spicy-hooks/observables"
+        "file": "packages/observables/CHANGELOG.md"
       },
       {
         "pattern": "^(## )`bin` - ",
-        "packageName": "@spicy-hooks/bin"
+        "file": "packages/bin/CHANGELOG.md"
       },
       {
         "pattern": "^(## )`utils` - ",
-        "packageName": "@spicy-hooks/utils"
+        "file": "packages/utils/CHANGELOG.md"
       }
     ]
   },

--- a/packages/bin/docs/prepare-release.md
+++ b/packages/bin/docs/prepare-release.md
@@ -19,18 +19,16 @@ This property defines how release notes of the latest draft release are parsed a
 
 ```json
 {
-  ...
-
   "changelogs": {
     "separator": "\n(?=## )",
     "mappings": [
       {
         "pattern": "(.)",
-        "packageName": "project-package"
+        "file": "CHANGELOG.md"
       },
       {
         "pattern": "^(## ) Package A - ",
-        "packageName": "package-a"
+        "file": "packages/package-a/CHANGELOG.md"
       },
       {
         "pattern": "^(## ) Package B - ",
@@ -60,12 +58,8 @@ A regular expression pattern that selects sections which should go into the targ
 **Important:** Note that the matching string is by default stripped of the text appended to the changelog.
 To make selected parts preserved, wrap them into a RegExp capture group (`(preserved) stripped`).
  
-#### `packageName` or `file`
-You can either specify a direct path to a concrete changelog by using the `file` or let the tool infer
-the location from a `packageName`.
-
-For example specifying `"packageName": "package-a"` will make the tool find a workspace package with a name `package-a`
-and use `<package-directory>/CHANGELOG.md` as the target changelog file.
+#### `file`
+Path to a target changelog that should be prepended with the matching sections.
  
 ## Synopsis
 

--- a/packages/bin/src/internal/commands/prepare-release-command.ts
+++ b/packages/bin/src/internal/commands/prepare-release-command.ts
@@ -63,7 +63,7 @@ export const prepareReleaseCommand: CommandDefinition<PrepareReleasesOptions> = 
     const settings = readSettings(rootPackage.packageJson)
 
     await setVersion(version, workspacePackages)
-    await writeChangelogs(draft, settings, workspacePackages)
+    await writeChangelogs(draft, settings, rootPackage.path)
     await writeAllPackages(workspacePackages)
 
     console.log(`Release ${draft.name} prepared for publishing... commit and push your changes!`)


### PR DESCRIPTION
This PR removes the `packageName` property of `package.json/changelogs` in favor of `file`.
As it just implied an unnecessary indirection and complexity.