### PR TITLE
Remove labeled tuples for improved compatibility with older TS versions

### DIFF
--- a/packages/core/src/internal/use-state-without-rerender.ts
+++ b/packages/core/src/internal/use-state-without-rerender.ts
@@ -30,7 +30,7 @@ interface ValueHolder<T> {
  * @typeParam S type of the state value
  * @category Hook
  */
-export function useStateWithoutRerender<S> (initialValue: S | (() => S)): [value: S, setValue: Dispatch<SetStateAction<S>>, silentlySetValue: Dispatch<SetStateAction<S>>] {
+export function useStateWithoutRerender<S> (initialValue: S | (() => S)): [S, Dispatch<SetStateAction<S>>, Dispatch<SetStateAction<S>>] {
   const [holder, setHolder] = useState<ValueHolder<S>>(
     isFunction(initialValue)
       ? () => ({ value: initialValue() })

--- a/packages/observables/src/internal/hooks/use-snapshot.ts
+++ b/packages/observables/src/internal/hooks/use-snapshot.ts
@@ -36,7 +36,7 @@ export enum SnapshotState {
  * @typeParam T type of the emitted value
  * @typeParam S `null` determines that state is nullable, the only only other acceptable type is `never`
  */
-export type Snapshot<T, S extends never | null = never> = [value: T, state: SnapshotState | S, error: Error | any | null]
+export type Snapshot<T, S extends never | null = never> = [T, SnapshotState | S, Error | any | null]
 
 const WaitingSymbol = Symbol('waiting for observable to emit')
 


### PR DESCRIPTION
While [labeled tuples](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-0.html#labeled-tuple-elements) is a neat feature it unfortunately breaks older TS parsers (even when found only in `d.ts `)

To ensure the highest possible compatibility, we're avoiding labeled tuples for now.