### PR TITLE
Add possibility to specify custom branch for `prepare-release`

### DIFF
--- a/packages/bin/docs/prepare-release.md
+++ b/packages/bin/docs/prepare-release.md
@@ -64,7 +64,7 @@ Path to a target changelog that should be prepended with the matching sections.
 ## Synopsis
 
 ```shell script
-spicy prepare-release [--token <github-token>] [--root path]
+spicy prepare-release [--token <github-token>] [--root path] [--branch string]
 ```
 
 ```shell script
@@ -80,6 +80,10 @@ spicy prepare-release --help
 * `-r, --root path`
     * Path to the root package (i.e. directory where the root `package.json` is located)
     * (defaults to `./`)
+                         
+* `-b, --branch string`
+    * Name of the branch that is being released and that is linked to the release draft
+    * (defaults to current Git branch)
     
 * `-h, --help`
     * Display usage guide

--- a/packages/bin/src/internal/commands/prepare-release-command.ts
+++ b/packages/bin/src/internal/commands/prepare-release-command.ts
@@ -10,6 +10,7 @@ const versionPattern = /^v(.+)$/
 interface PrepareReleasesOptions {
   root: string
   token?: string
+  branch?: string
 }
 
 export const prepareReleaseCommand: CommandDefinition<PrepareReleasesOptions> = {
@@ -40,10 +41,17 @@ export const prepareReleaseCommand: CommandDefinition<PrepareReleasesOptions> = 
       defaultValue: './',
       description: `Path to the root package (i.e. directory where the root {bold package.json} is located)
                     (defaults to {bold './'})`
+    },
+    branch: {
+      alias: 'b',
+      type: String,
+      required: false,
+      description: `Name of the branch that is being released and that is linked to the release draft
+                    (defaults to current Git branch)`
     }
   },
-  execute: async ({ root, token }) => {
-    const branchName = await getCurrentBranchName()
+  execute: async ({ root, branch, token }) => {
+    const branchName = branch ?? await getCurrentBranchName()
     const workspacePackages = await readAllPackages(root)
     const rootPackage = workspacePackages[0]
 


### PR DESCRIPTION
This PR adds a `--branch` option to `spicy prepare-release` command through which one can override the current Git branch.

Although it is generally a stupid idea to prepare a release for a different branch, it is very useful for debugging when you are on a feature branch and want to utilize the existing release draft on the main branch.