### PR TITLE
Make the `concurrent*` operators unsubscribe from source

### DIFF
--- a/packages/observables/src/internal/operators/concurrent-latest.ts
+++ b/packages/observables/src/internal/operators/concurrent-latest.ts
@@ -21,7 +21,7 @@ export function concurrentLatest<T> (cancelError?: any): OperatorFunction<Observ
     let pending$: Observable<T> = EMPTY
     let pendingSubject: Subject<T> | null = null
 
-    source.subscribe({
+    return source.subscribe({
       next: observable => {
         if (pendingSubject) {
           if (cancelError !== undefined) {

--- a/packages/observables/src/internal/operators/concurrent-one-and-latest.ts
+++ b/packages/observables/src/internal/operators/concurrent-one-and-latest.ts
@@ -35,7 +35,7 @@ export function concurrentOneAndLatest<T> (): OperatorFunction<Observable<T>, Ob
       }
     }
 
-    source.subscribe({
+    return source.subscribe({
       next: observable => {
         next$ = publish<T>()(observable)
         if (!pending$) {

--- a/packages/observables/src/internal/operators/concurrent-one.ts
+++ b/packages/observables/src/internal/operators/concurrent-one.ts
@@ -15,7 +15,7 @@ export function concurrentOne<T> (): OperatorFunction<Observable<T>, Observable<
   return source => new Observable(subscriber => {
     let pending$: Observable<T> | null = null
 
-    source.subscribe({
+    return source.subscribe({
       next: async observable => {
         if (pending$) {
           return

--- a/packages/observables/src/internal/operators/concurrent-queue.spec.ts
+++ b/packages/observables/src/internal/operators/concurrent-queue.spec.ts
@@ -1,4 +1,4 @@
-import { merge, of } from 'rxjs'
+import { merge, of, Subject } from 'rxjs'
 import { delay, mergeAll, tap, toArray } from 'rxjs/operators'
 import { latency } from '@spicy-hooks/utils'
 
@@ -156,5 +156,48 @@ describe('concurrentQueue', () => {
       'complete 2',
       'after complete 2'
     ])
+  })
+
+  it('unsubscribes from source when unsubscribed from (without emission)', () => {
+    const subject = new Subject<number>()
+
+    const pipeLine = subject.pipe(
+      bind(async (i) => {
+        await latency(50)
+        return `i: ${i}`
+      }),
+      coldFrom(),
+      concurrentQueue()
+    )
+
+    expect(subject.observers.length).toBe(0)
+
+    const subscription = pipeLine.subscribe({ next: () => undefined })
+
+    expect(subject.observers.length).toBe(1)
+
+    subscription.unsubscribe()
+
+    expect(subject.observers.length).toBe(0)
+  })
+
+  it('unsubscribes from source when unsubscribed from (wit emission)', () => {
+    const subject = new Subject<number>()
+
+    const pipeLine = subject.pipe(
+      bind(async (i) => {
+        await latency(50)
+        return `i: ${i}`
+      }),
+      coldFrom(),
+      concurrentQueue()
+    )
+
+    const subscription = pipeLine.subscribe({ next: () => undefined })
+
+    subject.next(1)
+
+    subscription.unsubscribe()
+    expect(subject.observers.length).toBe(0)
   })
 })

--- a/packages/observables/src/internal/operators/concurrent-queue.ts
+++ b/packages/observables/src/internal/operators/concurrent-queue.ts
@@ -12,7 +12,7 @@ import { publish } from 'rxjs/operators'
 export function concurrentQueue<T> (): OperatorFunction<Observable<T>, Observable<T>> {
   return source => new Observable(subscriber => {
     let tail$: Observable<T> = EMPTY
-    source.subscribe({
+    return source.subscribe({
       next: async observable => {
         const previous$ = tail$
         const current$ = publish<T>()(observable)


### PR DESCRIPTION
None of the `concurrent*` operators unsubscribed from the source when unsubscribed from. This was a critical bug.

Tests were added to each operator to prevent regression.

Resolves #35 